### PR TITLE
Remove obsolete header ndn-cxx/selectors.hpp

### DIFF
--- a/tools/ndndelfile.cpp
+++ b/tools/ndndelfile.cpp
@@ -6,7 +6,6 @@
 #include <ndn-cxx/security/key-chain.hpp>
 #include <ndn-cxx/security/signing-helpers.hpp>
 #include <ndn-cxx/util/scheduler.hpp>
-#include <ndn-cxx/selectors.hpp>
 
 #include "ndndelfile.hpp"
 


### PR DESCRIPTION
Cannot compile with the header selector.hpp